### PR TITLE
Loosen PHP version restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,39 @@ The release process [is described here](doc/Release.md).
 
 ## Prerequisites
 
-This library needs at least `PHP 5.6`.
-It has been successfully tested using `PHP 5.6`, `PHP 7` and `HHVM`
+This library needs at least `PHP 5.5.9`.
+It has been successfully tested using `PHP 5.5.9`, `PHP 5.6`, `PHP 7` and `HHVM`
 
 ## Installation
 
 The preferred way to install this library is to rely on Composer:
 
-```sh
-composer require "spomky-labs/otphp" "~6.0.0"
+##### 1. 
+
+Add the repo name to your `composer.json` file:
+
+```php
+"require": {
+    "spomky-labs/otphp": "~6.0.0",
+}
 ```
+
+##### 2.
+
+Then, override the git repo URL:
+
+```php
+"repositories": [
+    {
+        "type": "vcs",
+         "url": "https://github.com/your-github-username/torophp"
+    }
+]
+```
+
+##### 3.
+
+Lastly, run `composer update`
 
 ## TOTP or HOTP?
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.5.9",
         "christian-riesen/base32": "~1.1"
     },
     "require-dev": {


### PR DESCRIPTION
@JohnnyGoods @PhilipChen 
- As there's nothing that absolutely requires PHP 5.6 over PHP 5.5.9,
  the composer installation requirement has been changed. 
- Also updated README.md
